### PR TITLE
fix(tests): Update LayeredRevertableTxState tests for new API

### DIFF
--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/layered_revertable_tx_state.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/layered_revertable_tx_state.rs
@@ -448,23 +448,28 @@ mod tests {
             Some(value.clone())
         );
 
-        // Commit should panic since there are no layers
-        // (Changes were applied directly to inner state, no commit needed)
+        // Changes were applied directly to inner state, no commit needed
         // Verify the value is already in inner state
         let mut metric = StateAccessMetric::new_read();
         assert_eq!(
             layered_state.get_value(namespace, &key, &mut metric),
-            Some(value.clone())
+            Some(value)
         );
+    }
 
-        // Trying to commit with no layers should panic
-        let result = std::panic::catch_unwind(|| {
-            layered_state.commit_layer();
-        });
-        assert!(
-            result.is_err(),
-            "Expected panic when committing with no layers"
-        );
+    #[test]
+    #[should_panic(expected = "Cannot commit layer: no layers exist")]
+    fn test_commit_with_no_layers_panics() {
+        let storage_manager = SimpleStorageManager::new();
+        let storage = storage_manager.create_storage();
+
+        let mut working_set =
+            WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
+
+        let layered_state = LayeredRevertableTxState::new(&mut working_set);
+
+        // This should panic - no layers to commit
+        layered_state.commit_layer();
     }
 
     #[test]
@@ -501,7 +506,7 @@ mod tests {
         );
 
         // Revert the layer - should return LayeredRevertableTxState with no layers
-        let layered_state = layered_state.revert_layer();
+        let mut layered_state = layered_state.revert_layer();
         // Should have no layers now
         assert_eq!(layered_state.layer_depth(), 0);
         // Should see value1 from inner (direct write before layer was added)
@@ -520,8 +525,9 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        // Create layered state
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add a layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
 
         // Write some data
         let namespace = User::NAMESPACE;
@@ -531,7 +537,7 @@ mod tests {
         layered_state.set_value(namespace, &key, value.clone());
 
         // Commit the layer
-        let layered_state = layered_state.commit_layer();
+        let mut layered_state = layered_state.commit_layer();
         // Should have no layers now and value should be in inner state
         assert_eq!(layered_state.layer_depth(), 0);
         let mut metric = StateAccessMetric::new_read();
@@ -549,8 +555,9 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        // Create layered state
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add a layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
 
         // Write some data
         let namespace = User::NAMESPACE;
@@ -560,7 +567,7 @@ mod tests {
         layered_state.set_value(namespace, &key, value.clone());
 
         // Revert the layer - should return LayeredRevertableTxState with no layers
-        let layered_state = layered_state.revert_layer();
+        let mut layered_state = layered_state.revert_layer();
         // Should have no layers now
         assert_eq!(layered_state.layer_depth(), 0);
         // The write should be gone (it was in the layer)
@@ -576,8 +583,9 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        // Create first layer
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add first layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
 
         let namespace = User::NAMESPACE;
         let key1 = SlotKey::from_slice(b"key1");
@@ -614,7 +622,7 @@ mod tests {
         );
 
         // Commit first layer - should return LayeredRevertableTxState with no layers
-        let layered_state = layered_state.commit_layer();
+        let mut layered_state = layered_state.commit_layer();
         assert_eq!(layered_state.layer_depth(), 0);
         // Verify final state through the layered state
         let mut metric = StateAccessMetric::new_read();
@@ -639,8 +647,9 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        // Create first layer
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add first layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
 
         let namespace = User::NAMESPACE;
         let key1 = SlotKey::from_slice(b"key1");
@@ -677,7 +686,7 @@ mod tests {
         );
 
         // Commit first layer
-        let layered_state = layered_state.commit_layer();
+        let mut layered_state = layered_state.commit_layer();
         assert_eq!(layered_state.layer_depth(), 0);
         // Verify final state through the layered state
         let mut metric = StateAccessMetric::new_read();
@@ -702,8 +711,12 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        // Create first layer
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state (starts with 0 layers)
+        let mut layered_state = working_set.to_revertable_layered();
+        assert_eq!(layered_state.layer_depth(), 0);
+
+        // Add first layer
+        layered_state.add_revertable_layer();
         assert_eq!(layered_state.layer_depth(), 1);
 
         // Add second layer
@@ -723,8 +736,9 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        // Create first layer
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add first layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
         layered_state.add_event("test", "event1");
 
         // Add second layer
@@ -748,8 +762,9 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        // Create first layer
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add first layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
         let cache_key = SlotKey::from_slice(b"cache_key");
         layered_state.put_cached(Some(cache_key.clone()), "cached_value1".to_string());
 
@@ -781,8 +796,9 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        // Create layered state
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add a layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
 
         let namespace = User::NAMESPACE;
         let key = SlotKey::from_slice(b"test_key");
@@ -806,7 +822,7 @@ mod tests {
         assert_eq!(layered_state.get_value(namespace, &key, &mut metric), None);
 
         // Commit and verify delete is persisted
-        let layered_state = layered_state.commit_layer();
+        let mut layered_state = layered_state.commit_layer();
         assert_eq!(layered_state.layer_depth(), 0);
         let mut metric = StateAccessMetric::new_read();
         assert_eq!(
@@ -824,7 +840,9 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add first layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
 
         let namespace = User::NAMESPACE;
         let key = SlotKey::from_slice(b"test_key");
@@ -872,7 +890,9 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add first layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
 
         let namespace = User::NAMESPACE;
         let key = SlotKey::from_slice(b"test_key");
@@ -932,7 +952,7 @@ mod tests {
         StateWriter::<User>::set(&mut working_set, &key, value.clone()).unwrap();
 
         // Create layered state
-        let mut layered_state = working_set.add_revertable_layer();
+        let mut layered_state = working_set.to_revertable_layered();
 
         // Should be able to read from inner state
         let mut metric = StateAccessMetric::new_read();
@@ -958,10 +978,11 @@ mod tests {
         use crate::StateWriter;
         StateWriter::<User>::set(&mut working_set, &key, value.clone()).unwrap();
 
-        // Create layered state
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add a layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
 
-        // Verify it exists
+        // Verify it exists (readable from inner state)
         let mut metric = StateAccessMetric::new_read();
         assert_eq!(
             layered_state.get_value(namespace, &key, &mut metric),
@@ -976,7 +997,7 @@ mod tests {
         assert_eq!(layered_state.get_value(namespace, &key, &mut metric), None);
 
         // Commit and verify delete is persisted
-        let layered_state = layered_state.commit_layer();
+        let mut layered_state = layered_state.commit_layer();
         assert_eq!(layered_state.layer_depth(), 0);
         let mut metric = StateAccessMetric::new_read();
         assert_eq!(
@@ -994,7 +1015,7 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        let mut layered_state = working_set.add_revertable_layer();
+        let mut layered_state = working_set.to_revertable_layered();
         let cache_key = SlotKey::from_slice(b"cache_key");
 
         // Put value in cache
@@ -1020,7 +1041,7 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        let mut layered_state = working_set.add_revertable_layer();
+        let mut layered_state = working_set.to_revertable_layered();
         let cache_key = SlotKey::from_slice(b"cache_key");
 
         // Put value1 in layer1
@@ -1052,7 +1073,7 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        let mut layered_state = working_set.add_revertable_layer();
+        let mut layered_state = working_set.to_revertable_layered();
 
         let namespace = User::NAMESPACE;
         let key = SlotKey::from_slice(b"test_key");
@@ -1078,7 +1099,9 @@ mod tests {
         let mut working_set =
             WorkingSet::<TestSpec>::new_with_kernel(storage, &MockKernel::<TestSpec>::default());
 
-        let mut layered_state = working_set.add_revertable_layer();
+        // Create layered state and add first layer
+        let mut layered_state = working_set.to_revertable_layered();
+        layered_state.add_revertable_layer();
 
         let namespace = User::NAMESPACE;
         let key = SlotKey::from_slice(b"test_key");
@@ -1118,7 +1141,7 @@ mod tests {
         );
 
         // Commit layer1 -> inner state
-        let layered_state = layered_state.commit_layer();
+        let mut layered_state = layered_state.commit_layer();
         assert_eq!(layered_state.layer_depth(), 0);
         let mut metric = StateAccessMetric::new_read();
         assert_eq!(


### PR DESCRIPTION
## Summary
- Update tests to use `to_revertable_layered()` + `add_revertable_layer()` instead of the removed `add_revertable_layer()` method on WorkingSet
- Split `catch_unwind` panic test into separate `#[should_panic]` test for cleaner testing
- Fix variable mutability issues after `revert_layer()` and `commit_layer()` calls
- Update `test_layer_depth` to expect 0 layers initially

## Test plan
- [x] All 24 LayeredRevertableTxState tests pass
- [x] No warnings in test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)