### PR TITLE
feat: auto-credit gas tokens on Hyperlane bridge

### DIFF
--- a/crates/module-system/hyperlane/src/warp/mod.rs
+++ b/crates/module-system/hyperlane/src/warp/mod.rs
@@ -110,6 +110,9 @@ pub enum CallMessage<S: Spec> {
         /// Usually this should be set to a value which allows full limit recovery each day,
         /// so `transferrable_tokens_limit / DA_SLOTS_PER_DAY`.
         outbound_limit_replenishment_per_slot: Amount,
+        /// Target gas token balance for bridge recipients. If set, the route will transfer gas
+        /// tokens from its reserve to top off recipients on inbound transfers.
+        gas_credit_amount: Option<Amount>,
     },
     /// Update an existing route with new admin or ISM.
     Update {
@@ -127,6 +130,9 @@ pub enum CallMessage<S: Spec> {
         outbound_transferrable_tokens_limit: Option<Amount>,
         /// Defines how many tokens are added to the outbound transferrable limit at each visible slot.
         outbound_limit_replenishment_per_slot: Option<Amount>,
+        /// Update gas credit amount. `Some(Some(amount))` sets it, `Some(None)` disables it,
+        /// `None` leaves it unchanged.
+        gas_credit_amount: Option<Option<Amount>>,
     },
     /// Add a counterparty router on another chain. This router is trusted. A malicious remote router can steal funds.
     /// Each warp route can have at most one remote router for a given destination domain.
@@ -159,6 +165,14 @@ pub enum CallMessage<S: Spec> {
         relayer: Option<S::Address>,
         /// A limit for the payment to relayer to cover gas needed for message delivery.
         gas_payment_limit: Amount,
+    },
+    /// Fund a warp route's gas reserve with gas tokens. The sender's gas tokens are transferred
+    /// to the route's derived holder, which is used to top off bridge recipients.
+    FundGasReserve {
+        /// The ID of the warp route to fund.
+        warp_route: WarpRouteId,
+        /// The amount of gas tokens to deposit.
+        amount: Amount,
     },
 }
 
@@ -260,6 +274,24 @@ pub enum Event<S: Spec> {
         /// The amount transferred, in *local* token units.
         amount: Amount,
     },
+    /// Gas reserve was funded for a warp route.
+    GasReserveFunded {
+        /// The ID of the warp route.
+        route_id: WarpRouteId,
+        /// The funder who deposited gas tokens.
+        funder: HexHash,
+        /// The amount of gas tokens deposited.
+        amount: Amount,
+    },
+    /// Gas tokens were credited to a bridge recipient from the route's reserve.
+    GasCredited {
+        /// The ID of the warp route.
+        route_id: WarpRouteId,
+        /// The recipient who received the gas credit.
+        recipient: HexHash,
+        /// The amount of gas tokens credited.
+        amount: Amount,
+    },
 }
 
 impl<S: Spec> Module for Warp<S>
@@ -288,6 +320,7 @@ where
                 inbound_limit_replenishment_per_slot,
                 outbound_transferrable_tokens_limit,
                 outbound_limit_replenishment_per_slot,
+                gas_credit_amount,
             } => {
                 self.register(
                     admin,
@@ -298,6 +331,7 @@ where
                     inbound_limit_replenishment_per_slot,
                     outbound_transferrable_tokens_limit,
                     outbound_limit_replenishment_per_slot,
+                    gas_credit_amount,
                     context,
                     state,
                 )?;
@@ -310,6 +344,7 @@ where
                 inbound_limit_replenishment_per_slot,
                 outbound_transferrable_tokens_limit,
                 outbound_limit_replenishment_per_slot,
+                gas_credit_amount,
             } => {
                 self.update(
                     warp_route,
@@ -319,6 +354,7 @@ where
                     inbound_limit_replenishment_per_slot,
                     outbound_transferrable_tokens_limit,
                     outbound_limit_replenishment_per_slot,
+                    gas_credit_amount,
                     context,
                     state,
                 )?;
@@ -341,6 +377,9 @@ where
                 remote_domain,
             } => {
                 self.unenroll_remote_router(warp_route, remote_domain, context, state)?;
+            }
+            CallMessage::FundGasReserve { warp_route, amount } => {
+                self.fund_gas_reserve(warp_route, amount, context, state)?;
             }
             CallMessage::TransferRemote {
                 warp_route,
@@ -411,6 +450,7 @@ where
         inbound_limit_replenishment_per_slot: Amount,
         outbound_transferrable_tokens_limit: Amount,
         outbound_limit_replenishment_per_slot: Amount,
+        gas_credit_amount: Option<Amount>,
         context: &Context<S>,
         state: &mut impl TxState<S>,
     ) -> anyhow::Result<()> {
@@ -464,6 +504,7 @@ where
                 outbound_limit_replenishment_per_slot,
                 state,
             ),
+            gas_credit_amount,
         };
 
         self.emit_event(
@@ -509,6 +550,7 @@ where
         inbound_limit_replenishment_per_slot: Option<Amount>,
         outbound_transferrable_tokens_limit: Option<Amount>,
         outbound_limit_replenishment_per_slot: Option<Amount>,
+        gas_credit_amount: Option<Option<Amount>>,
         context: &Context<S>,
         state: &mut impl TxState<S>,
     ) -> anyhow::Result<()> {
@@ -525,10 +567,14 @@ where
             || inbound_limit_replenishment_per_slot.is_some();
         let outbound_rate_limit_updated = outbound_transferrable_tokens_limit.is_some()
             || outbound_limit_replenishment_per_slot.is_some();
+        let gas_credit_updated = gas_credit_amount.is_some();
 
         anyhow::ensure!(
-            admin_or_ism_updated || inbound_rate_limit_updated || outbound_rate_limit_updated,
-            "Update should contain new admin, ism, or rate limit settings"
+            admin_or_ism_updated
+                || inbound_rate_limit_updated
+                || outbound_rate_limit_updated
+                || gas_credit_updated,
+            "Update should contain new admin, ism, rate limit, or gas credit settings"
         );
 
         // Check if the request is properly authorized
@@ -611,6 +657,11 @@ where
             });
         }
 
+        // Update gas credit amount
+        if let Some(new_gas_credit) = gas_credit_amount {
+            route.gas_credit_amount = new_gas_credit;
+        }
+
         // save the new state and emit events.
         route.save(state)?;
         for event in events {
@@ -637,6 +688,41 @@ where
             holder.to_payable(), // The mint authority is the warp route
             state,
         )?)
+    }
+
+    /// Fund a warp route's gas reserve by transferring gas tokens from the sender to the route's
+    /// derived holder. Anyone can fund any route's gas reserve.
+    fn fund_gas_reserve(
+        &mut self,
+        route_id: WarpRouteId,
+        amount: Amount,
+        context: &Context<S>,
+        state: &mut impl TxState<S>,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.warp_routes.get(&route_id, state)?.is_some(),
+            "Warp route {} not found",
+            route_id
+        );
+        let route_holder: DerivedHolder = route_id.0.into();
+        self.bank.transfer_from(
+            context.sender(),
+            route_holder.to_payable(),
+            Coins {
+                amount,
+                token_id: config_gas_token_id(),
+            },
+            state,
+        )?;
+        self.emit_event(
+            state,
+            Event::GasReserveFunded {
+                route_id,
+                funder: context.sender().to_sender(),
+                amount,
+            },
+        );
+        Ok(())
     }
 
     /// "Enroll" a remote router on another chain. Whenever this route needs to send/receive funds on that chain,
@@ -1028,6 +1114,47 @@ where
                 )?;
             }
         };
+
+        // Gas credit: top off the recipient's gas token balance from the route's reserve.
+        // Skip for Native routes (the bridged token IS the gas token).
+        if let Some(target_gas) = route.gas_credit_amount {
+            if !matches!(route.token_source, StoredTokenKind::Native) {
+                let current = self
+                    .bank
+                    .get_balance_of(&token_recipient, config_gas_token_id(), state)
+                    .unwrap_or(None)
+                    .unwrap_or_default();
+                if current < target_gas {
+                    let top_off = Amount(target_gas.0 - current.0);
+                    // Non-fatal: if the route reserve is depleted, the bridge still succeeds
+                    match self.bank.transfer_from(
+                        route_token_holder.to_payable(),
+                        &token_recipient,
+                        Coins {
+                            amount: top_off,
+                            token_id: config_gas_token_id(),
+                        },
+                        state,
+                    ) {
+                        Ok(()) => {
+                            self.emit_event(
+                                state,
+                                Event::GasCredited {
+                                    route_id: *route_id,
+                                    recipient: token_recipient_hex,
+                                    amount: top_off,
+                                },
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Gas credit failed for route {route_id} (reserve may be depleted): {e}"
+                            );
+                        }
+                    }
+                }
+            }
+        }
 
         self.emit_event(
             state,

--- a/crates/module-system/hyperlane/src/warp/types.rs
+++ b/crates/module-system/hyperlane/src/warp/types.rs
@@ -375,6 +375,10 @@ pub struct WarpRouteInstance<S: Spec> {
     pub inbound_rate_limiter: RateLimiter,
     /// Outbound transfers rate limiter.
     pub outbound_rate_limiter: RateLimiter,
+    /// Target gas token balance for bridge recipients. If set, the route
+    /// will transfer gas tokens from its reserve to top off recipients
+    /// whose gas balance is below this amount on inbound transfers.
+    pub gas_credit_amount: Option<Amount>,
 }
 
 #[derive(

--- a/crates/module-system/hyperlane/tests/integration/warp/bridged_gas_token.rs
+++ b/crates/module-system/hyperlane/tests/integration/warp/bridged_gas_token.rs
@@ -171,6 +171,7 @@ pub fn register_warp_route_gasless(
                 inbound_limit_replenishment_per_slot: Amount::MAX,
                 outbound_transferrable_tokens_limit: Amount::MAX,
                 outbound_limit_replenishment_per_slot: Amount::MAX,
+                gas_credit_amount: None,
             }),
             key: user.private_key.clone(),
             details: TxDetails {

--- a/crates/module-system/hyperlane/tests/integration/warp/enroll.rs
+++ b/crates/module-system/hyperlane/tests/integration/warp/enroll.rs
@@ -249,6 +249,7 @@ fn test_register_warp_route_duplicate_registrations_fail() {
             inbound_limit_replenishment_per_slot: Amount::MAX,
             outbound_transferrable_tokens_limit: Amount::MAX,
             outbound_limit_replenishment_per_slot: Amount::MAX,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             match result.tx_receipt {
@@ -281,6 +282,7 @@ fn test_enroll_remote_routers_on_registration() {
             inbound_limit_replenishment_per_slot: Amount::MAX,
             outbound_transferrable_tokens_limit: Amount::MAX,
             outbound_limit_replenishment_per_slot: Amount::MAX,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(
@@ -332,6 +334,7 @@ fn test_enroll_remote_routers_on_registration_fails_on_duplicates() {
             inbound_limit_replenishment_per_slot: Amount::MAX,
             outbound_transferrable_tokens_limit: Amount::MAX,
             outbound_limit_replenishment_per_slot: Amount::MAX,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             match result.tx_receipt {
@@ -362,6 +365,7 @@ fn test_warp_route_updates() {
             inbound_limit_replenishment_per_slot: None,
             outbound_transferrable_tokens_limit: None,
             outbound_limit_replenishment_per_slot: None,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(
@@ -382,6 +386,7 @@ fn test_warp_route_updates() {
             inbound_limit_replenishment_per_slot: None,
             outbound_transferrable_tokens_limit: None,
             outbound_limit_replenishment_per_slot: None,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(
@@ -412,6 +417,7 @@ fn test_warp_route_updates() {
             inbound_limit_replenishment_per_slot: None,
             outbound_transferrable_tokens_limit: None,
             outbound_limit_replenishment_per_slot: None,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(
@@ -440,6 +446,7 @@ fn test_warp_route_updates() {
             inbound_limit_replenishment_per_slot: Some(Amount(4321)),
             outbound_transferrable_tokens_limit: Some(Amount(1234)),
             outbound_limit_replenishment_per_slot: Some(Amount(4321)),
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(
@@ -495,6 +502,7 @@ fn test_warp_route_updates() {
                 inbound_limit_replenishment_per_slot: None,
                 outbound_transferrable_tokens_limit: None,
                 outbound_limit_replenishment_per_slot: None,
+                gas_credit_amount: None,
             }),
             assert: Box::new(move |result, _| {
                 assert!(
@@ -522,6 +530,7 @@ fn test_warp_route_independent_limits() {
             inbound_limit_replenishment_per_slot: Some(Amount(4321)),
             outbound_transferrable_tokens_limit: None,
             outbound_limit_replenishment_per_slot: None,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(
@@ -557,6 +566,7 @@ fn test_warp_route_independent_limits() {
             inbound_limit_replenishment_per_slot: None,
             outbound_transferrable_tokens_limit: Some(Amount(1234)),
             outbound_limit_replenishment_per_slot: Some(Amount(4321)),
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(
@@ -599,6 +609,7 @@ fn test_warp_route_limit_updates() {
                 inbound_limit_replenishment_per_slot: replenishment,
                 outbound_transferrable_tokens_limit: max,
                 outbound_limit_replenishment_per_slot: replenishment,
+                gas_credit_amount: None,
             }),
             assert: Box::new(move |result, _| {
                 assert!(

--- a/crates/module-system/hyperlane/tests/integration/warp/runtime.rs
+++ b/crates/module-system/hyperlane/tests/integration/warp/runtime.rs
@@ -167,6 +167,7 @@ pub fn register_warp_route_with_ism_and_token_source_and_rate_limiter(
             inbound_limit_replenishment_per_slot: limit_replenishment_per_slot,
             outbound_transferrable_tokens_limit: transferrable_tokens_limit,
             outbound_limit_replenishment_per_slot: limit_replenishment_per_slot,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(

--- a/crates/module-system/hyperlane/tests/integration/warp/transfer.rs
+++ b/crates/module-system/hyperlane/tests/integration/warp/transfer.rs
@@ -12,7 +12,7 @@ use sov_modules_api::macros::config_value;
 use sov_modules_api::prelude::UnwrapInfallible;
 use sov_modules_api::{HexHash, HexString, SafeVec, Spec, TxEffect, VersionReader};
 use sov_test_utils::runtime::TestRunner;
-use sov_test_utils::{AsUser, TestUser, TransactionTestCase};
+use sov_test_utils::{AsUser, TestUser, TransactionTestCase, TEST_DEFAULT_USER_BALANCE};
 
 use super::runtime::*;
 
@@ -518,6 +518,7 @@ fn test_inbound_transfer_after_ism_update() {
             inbound_limit_replenishment_per_slot: None,
             outbound_transferrable_tokens_limit: None,
             outbound_limit_replenishment_per_slot: None,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(
@@ -851,6 +852,7 @@ fn register_synthetic_route(
             inbound_limit_replenishment_per_slot: Amount::MAX,
             outbound_transferrable_tokens_limit: Amount::MAX,
             outbound_limit_replenishment_per_slot: Amount::MAX,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(
@@ -992,4 +994,331 @@ fn test_synthetic_route_without_scaling() {
         Amount(100),
         Amount(100),
     );
+}
+
+// --- Gas Credit Tests ---
+
+/// The amount each gas credit top-off delivers (target minus genesis balance).
+const GAS_CREDIT_TOP_OFF: Amount = Amount(100_000_000_000);
+
+/// Gas credit target: genesis balance + top-off, so inbound transfers always trigger a credit.
+const GAS_CREDIT_TARGET: Amount = Amount(TEST_DEFAULT_USER_BALANCE.0 + GAS_CREDIT_TOP_OFF.0);
+
+/// How many gas tokens to seed into the route reserve (4x top-off for comfortable margin).
+const GAS_RESERVE_FUND_AMOUNT: Amount = Amount(GAS_CREDIT_TOP_OFF.0 * 4);
+
+/// Default bridge amount for gas credit tests.
+const GAS_CREDIT_BRIDGE_AMOUNT: Amount = Amount(100);
+
+/// Register a synthetic warp route with gas_credit_amount set.
+fn register_synthetic_route_with_gas_credit(
+    runner: &mut TestRunner<RT, S>,
+    admin: &TestUser<S>,
+    gas_credit_amount: Amount,
+) -> (HexHash, TokenId) {
+    let warp_route_id = Arc::new(std::sync::Mutex::new(HexString([0; 32])));
+    let warp_route_id_ref = warp_route_id.clone();
+    let local_token_id = Arc::new(std::sync::Mutex::new(None));
+    let local_token_id_ref = local_token_id.clone();
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Warp<S>>(WarpCallMessage::Register {
+            admin: Admin::InsecureOwner(admin.address()),
+            token_source: TokenKind::Synthetic {
+                remote_token_id: HexString([255; 32]),
+                remote_decimals: 18,
+                local_decimals: None,
+            },
+            ism: Ism::AlwaysTrust,
+            remote_routers: SafeVec::new(),
+            inbound_transferrable_tokens_limit: Amount::MAX,
+            inbound_limit_replenishment_per_slot: Amount::MAX,
+            outbound_transferrable_tokens_limit: Amount::MAX,
+            outbound_limit_replenishment_per_slot: Amount::MAX,
+            gas_credit_amount: Some(gas_credit_amount),
+        }),
+        assert: Box::new(move |result, _| {
+            assert!(
+                result.tx_receipt.is_successful(),
+                "Route registration should succeed"
+            );
+            for event in result.events {
+                if let TestRuntimeEvent::Warp(WarpEvent::RouteRegistered {
+                    route_id,
+                    token_source,
+                    ..
+                }) = event
+                {
+                    *warp_route_id_ref.lock().unwrap() = route_id;
+                    let StoredTokenKind::Synthetic { local_token_id, .. } = token_source else {
+                        panic!("Token source should be synthetic");
+                    };
+                    *local_token_id_ref.lock().unwrap() = Some(local_token_id);
+                }
+            }
+        }),
+    });
+    let route_id = *warp_route_id.lock().unwrap();
+    let token_id = local_token_id.lock().unwrap().unwrap();
+    assert_ne!(
+        route_id,
+        HexString([0; 32]),
+        "Warp route was not registered"
+    );
+    (route_id, token_id)
+}
+
+/// Fund a warp route's gas reserve with gas tokens via the Warp module's FundGasReserve call.
+fn fund_route_gas_reserve(
+    runner: &mut TestRunner<RT, S>,
+    funder: &TestUser<S>,
+    route_id: HexHash,
+    amount: Amount,
+) {
+    runner.execute_transaction(TransactionTestCase {
+        input: funder.create_plain_message::<RT, Warp<S>>(WarpCallMessage::FundGasReserve {
+            warp_route: route_id,
+            amount,
+        }),
+        assert: Box::new(move |result, _| {
+            assert!(
+                result.tx_receipt.is_successful(),
+                "Funding route gas reserve should succeed: {:?}",
+                result.tx_receipt
+            );
+        }),
+    });
+}
+
+#[test]
+fn test_gas_credit_on_inbound_transfer() {
+    let (mut runner, admin, other, relayer) = setup();
+
+    register_relayer_with_dummy_igp(&mut runner, &relayer, CONFIGURED_DOMAIN);
+
+    let (warp_route_id, synthetic_token_id) =
+        register_synthetic_route_with_gas_credit(&mut runner, &admin, GAS_CREDIT_TARGET);
+    enroll_router(&mut runner, &admin, warp_route_id);
+    fund_route_gas_reserve(&mut runner, &admin, warp_route_id, GAS_RESERVE_FUND_AMOUNT);
+
+    // Verify recipient's genesis balance is below the credit target
+    let other_initial_gas = runner.query_state(|state| {
+        let bank = Bank::<S>::default();
+        bank.get_balance_of(&other.address(), config_gas_token_id(), state)
+            .unwrap_infallible()
+            .unwrap_or_default()
+    });
+    assert!(
+        other_initial_gas < GAS_CREDIT_TARGET,
+        "Initial gas balance ({other_initial_gas}) should be below target ({GAS_CREDIT_TARGET})"
+    );
+
+    // Do an inbound transfer of synthetic tokens to the "other" user
+    let message_body = {
+        let mut out = Vec::with_capacity(64);
+        out.extend_from_slice(&other.address().to_sender().0);
+        out.extend_from_slice(&encode_amount(GAS_CREDIT_BRIDGE_AMOUNT).0);
+        out
+    };
+    let message = inbound_message(
+        CONFIGURED_DOMAIN,
+        CONFIGURED_REMOTE_ROUTER_ADDRESS,
+        warp_route_id,
+        message_body,
+    );
+
+    let other_addr = other.address();
+    let other_sender = other.address().to_sender();
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Mailbox<S, Warp<S>>>(CallMessage::Process {
+            metadata: HexString(vec![].try_into().unwrap()),
+            message: HexString(message.encode().0.try_into().unwrap()),
+        }),
+        assert: Box::new(move |result, state| {
+            assert!(
+                result.tx_receipt.is_successful(),
+                "Inbound transfer should succeed: {:?}",
+                result.tx_receipt
+            );
+
+            // Check GasCredited event was emitted
+            assert!(
+                result.events.iter().any(|event| matches!(
+                    event,
+                    TestRuntimeEvent::Warp(WarpEvent::GasCredited {
+                        route_id,
+                        recipient,
+                        ..
+                    }) if route_id == &warp_route_id && recipient == &other_sender
+                )),
+                "GasCredited event should be emitted"
+            );
+
+            // Check recipient received synthetic tokens
+            let bank = Bank::<S>::default();
+            let synth_balance = bank
+                .get_balance_of(&other_addr, synthetic_token_id, state)
+                .unwrap_infallible()
+                .unwrap_or_default();
+            assert_eq!(
+                synth_balance, GAS_CREDIT_BRIDGE_AMOUNT,
+                "Should receive synthetic tokens"
+            );
+
+            // Check recipient's gas balance was topped up to target
+            let gas_balance = bank
+                .get_balance_of(&other_addr, config_gas_token_id(), state)
+                .unwrap_infallible()
+                .unwrap_or_default();
+            assert_eq!(
+                gas_balance, GAS_CREDIT_TARGET,
+                "Gas balance should be topped up to target"
+            );
+        }),
+    });
+}
+
+#[test]
+fn test_gas_credit_no_double_credit() {
+    let (mut runner, admin, other, relayer) = setup();
+
+    register_relayer_with_dummy_igp(&mut runner, &relayer, CONFIGURED_DOMAIN);
+
+    let (warp_route_id, _synthetic_token_id) =
+        register_synthetic_route_with_gas_credit(&mut runner, &admin, GAS_CREDIT_TARGET);
+    enroll_router(&mut runner, &admin, warp_route_id);
+
+    fund_route_gas_reserve(&mut runner, &admin, warp_route_id, GAS_RESERVE_FUND_AMOUNT);
+
+    // Helper to do an inbound bridge
+    let do_bridge = |runner: &mut TestRunner<RT, S>| {
+        let message_body = {
+            let mut out = Vec::with_capacity(64);
+            out.extend_from_slice(&other.address().to_sender().0);
+            out.extend_from_slice(&encode_amount(GAS_CREDIT_BRIDGE_AMOUNT).0);
+            out
+        };
+        let message = inbound_message(
+            CONFIGURED_DOMAIN,
+            CONFIGURED_REMOTE_ROUTER_ADDRESS,
+            warp_route_id,
+            message_body,
+        );
+        runner.execute_transaction(TransactionTestCase {
+            input: admin.create_plain_message::<RT, Mailbox<S, Warp<S>>>(CallMessage::Process {
+                metadata: HexString(vec![].try_into().unwrap()),
+                message: HexString(message.encode().0.try_into().unwrap()),
+            }),
+            assert: Box::new(move |result, _| {
+                assert!(
+                    result.tx_receipt.is_successful(),
+                    "Inbound transfer should succeed: {:?}",
+                    result.tx_receipt
+                );
+            }),
+        });
+    };
+
+    do_bridge(&mut runner);
+
+    // Record gas balance after first bridge
+    let gas_after_first = runner.query_state(|state| {
+        let bank = Bank::<S>::default();
+        bank.get_balance_of(&other.address(), config_gas_token_id(), state)
+            .unwrap_infallible()
+            .unwrap_or_default()
+    });
+
+    // Second inbound transfer - should NOT credit again since balance is already at/above target
+    do_bridge(&mut runner);
+
+    let gas_after_second = runner.query_state(|state| {
+        let bank = Bank::<S>::default();
+        bank.get_balance_of(&other.address(), config_gas_token_id(), state)
+            .unwrap_infallible()
+            .unwrap_or_default()
+    });
+
+    assert_eq!(
+        gas_after_first, gas_after_second,
+        "Gas balance should not change on second bridge (already at/above target)"
+    );
+}
+
+#[test]
+fn test_gas_credit_depleted_reserve_bridge_succeeds() {
+    let (mut runner, admin, other, relayer) = setup();
+
+    register_relayer_with_dummy_igp(&mut runner, &relayer, CONFIGURED_DOMAIN);
+
+    // Target above genesis balance so credit is attempted, but do NOT fund the route
+    let (warp_route_id, synthetic_token_id) =
+        register_synthetic_route_with_gas_credit(&mut runner, &admin, GAS_CREDIT_TARGET);
+    enroll_router(&mut runner, &admin, warp_route_id);
+
+    // Record initial gas balance
+    let gas_before = runner.query_state(|state| {
+        let bank = Bank::<S>::default();
+        bank.get_balance_of(&other.address(), config_gas_token_id(), state)
+            .unwrap_infallible()
+            .unwrap_or_default()
+    });
+
+    // Inbound transfer should still succeed even though gas credit will fail
+    let message_body = {
+        let mut out = Vec::with_capacity(64);
+        out.extend_from_slice(&other.address().to_sender().0);
+        out.extend_from_slice(&encode_amount(GAS_CREDIT_BRIDGE_AMOUNT).0);
+        out
+    };
+    let message = inbound_message(
+        CONFIGURED_DOMAIN,
+        CONFIGURED_REMOTE_ROUTER_ADDRESS,
+        warp_route_id,
+        message_body,
+    );
+
+    let other_addr = other.address();
+    runner.execute_transaction(TransactionTestCase {
+        input: admin.create_plain_message::<RT, Mailbox<S, Warp<S>>>(CallMessage::Process {
+            metadata: HexString(vec![].try_into().unwrap()),
+            message: HexString(message.encode().0.try_into().unwrap()),
+        }),
+        assert: Box::new(move |result, state| {
+            assert!(
+                result.tx_receipt.is_successful(),
+                "Inbound transfer should succeed even if gas credit fails: {:?}",
+                result.tx_receipt
+            );
+
+            // No GasCredited event should be emitted
+            assert!(
+                !result.events.iter().any(|event| matches!(
+                    event,
+                    TestRuntimeEvent::Warp(WarpEvent::GasCredited { .. })
+                )),
+                "GasCredited event should NOT be emitted when reserve is depleted"
+            );
+
+            // Recipient should still receive synthetic tokens
+            let bank = Bank::<S>::default();
+            let synth_balance = bank
+                .get_balance_of(&other_addr, synthetic_token_id, state)
+                .unwrap_infallible()
+                .unwrap_or_default();
+            assert_eq!(
+                synth_balance, GAS_CREDIT_BRIDGE_AMOUNT,
+                "Should still receive synthetic tokens"
+            );
+
+            // Gas balance should be unchanged
+            let gas_after = bank
+                .get_balance_of(&other_addr, config_gas_token_id(), state)
+                .unwrap_infallible()
+                .unwrap_or_default();
+            assert_eq!(
+                gas_before, gas_after,
+                "Gas balance should be unchanged when reserve is depleted"
+            );
+        }),
+    });
 }

--- a/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
+++ b/crates/module-system/hyperlane/tests/integration/with_agent/mod.rs
@@ -448,6 +448,7 @@ async fn test_warp_transfer_back_and_forth_with_evm_counterparty(
         inbound_limit_replenishment_per_slot: Amount::MAX,
         outbound_transferrable_tokens_limit: Amount::MAX,
         outbound_limit_replenishment_per_slot: Amount::MAX,
+        gas_credit_amount: None,
     });
     let register_tx = encode_call(relayer.private_key(), &register_call);
     submit_tx(rollup.api_client(), register_tx).await;

--- a/crates/module-system/module-implementations/extern/hyperlane-solana-register/tests/integration/setup.rs
+++ b/crates/module-system/module-implementations/extern/hyperlane-solana-register/tests/integration/setup.rs
@@ -112,6 +112,7 @@ pub fn register_warp_route_with_ism_and_token_source(
             inbound_limit_replenishment_per_slot: Amount::MAX,
             outbound_transferrable_tokens_limit: Amount::MAX,
             outbound_limit_replenishment_per_slot: Amount::MAX,
+            gas_credit_amount: None,
         }),
         assert: Box::new(move |result, _| {
             assert!(


### PR DESCRIPTION
## Summary

- Adds configurable `gas_credit_amount` to Warp Routes that automatically tops off recipients' gas token balance from the route's DerivedHolder reserve on inbound bridge transfers
- Adds `FundGasReserve` call message to fund the route's gas reserve (needed because `DerivedHolder` can't receive tokens via normal `Transfer`)
- Non-fatal: if the reserve is depleted, the bridge transfer still succeeds without gas credit

## Changes

- `WarpRouteInstance`: new `gas_credit_amount: Option<Amount>` field
- `CallMessage::Register` / `Update`: accept `gas_credit_amount`
- `CallMessage::FundGasReserve`: transfers gas tokens from sender to route's DerivedHolder
- `Recipient::handle()`: after mint/transfer, tops off recipient gas if below target
- New events: `GasCredited`, `GasReserveFunded`

## Test plan

- [x] `test_gas_credit_on_inbound_transfer` — verifies recipient gets topped off
- [x] `test_gas_credit_no_double_credit` — verifies no excess credit on second bridge
- [x] `test_gas_credit_depleted_reserve_bridge_succeeds` — verifies bridge works when reserve is empty
- [x] All existing hyperlane tests pass (58/58, excluding Docker-dependent with_agent tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)