### PR TITLE
feat: add priority fee bips billing to gas payer layers

### DIFF
--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/layered_revertable_tx_state.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/layered_revertable_tx_state.rs
@@ -13,6 +13,7 @@ use super::super::{BorshSerializedSize, StateMetricsProvider, UniversalStateAcce
 use crate::module::Spec;
 use crate::state::traits::delegate_version_reader;
 use crate::state::traits::PerBlockCache;
+use crate::transaction::PriorityFeeBips;
 use crate::{
     AccessoryStateWriter, Amount, BasicGasMeter, Gas, GasArray, GasBiller, GasBillingError,
     GasMeter, GasMeteringError, ProvableStateReader, ProvableStateWriter, TxState,
@@ -42,8 +43,7 @@ pub struct GasSnapshot<S: Spec> {
     /// Gas price at layer creation (for refund calculation).
     pub gas_price: <S::Gas as Gas>::Price,
     /// Priority fee rate in basis points (1 bip = 0.01%).
-    /// Priority fee = actual_base_cost * priority_fee_bips / 10_000.
-    pub priority_fee_bips: u64,
+    pub priority_fee_bips: PriorityFeeBips,
 }
 
 /// Billing info extracted from a layer before it's consumed (committed/reverted).
@@ -308,8 +308,11 @@ impl<'a, S: Spec, I: TxState<S>> LayeredRevertableTxState<'a, S, I> {
         }; // meter borrow dropped
 
         // Include priority fee in the upfront reservation so the full amount is locked
-        // before execution. upfront = base_cost + base_cost * priority_fee_bips / 10_000
-        let priority_reservation = Amount(gas_cost.0 * priority_fee_bips as u128 / 10_000);
+        // before execution. upfront = base_cost + priority_fee(base_cost)
+        let priority_fee_bips = PriorityFeeBips(priority_fee_bips);
+        let priority_reservation = priority_fee_bips
+            .apply(gas_cost)
+            .unwrap_or(Amount::ZERO);
         let upfront_charge = Amount(gas_cost.0.saturating_add(priority_reservation.0));
 
         // Phase 2: Read gas payer's balance (borrow self.inner as StateAccessor)
@@ -391,9 +394,12 @@ impl<'a, S: Spec, I: TxState<S>> LayeredRevertableTxState<'a, S, I> {
         // Phase 1: Calculate actual gas cost using stored gas_price
         let actual_cost = info.gas_consumed.value(info.gas_snapshot.gas_price);
 
-        // Priority fee is charged on actual consumption: actual_base * priority_fee_bips / 10_000
-        let actual_priority_fee =
-            Amount(actual_cost.0 * info.gas_snapshot.priority_fee_bips as u128 / 10_000);
+        // Priority fee is charged on actual consumption only
+        let actual_priority_fee = info
+            .gas_snapshot
+            .priority_fee_bips
+            .apply(actual_cost)
+            .unwrap_or(Amount::ZERO);
         let actual_total = Amount(actual_cost.0.saturating_add(actual_priority_fee.0));
 
         // Phase 2: Calculate and transfer refund (borrow self.inner as StateAccessor)

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/layered_revertable_tx_state.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/layered_revertable_tx_state.rs
@@ -798,6 +798,10 @@ mod tests {
         balance: Option<Amount>,
         /// Track total amount transferred (for test assertions)
         total_transferred: Amount,
+        /// Track total amount refunded (sequencer → payer transfers)
+        total_refunded: Amount,
+        /// The sequencer address, used to detect refund direction
+        sequencer: Option<<TestSpec as crate::Spec>::Address>,
     }
 
     impl MockBiller {
@@ -805,6 +809,20 @@ mod tests {
             Self {
                 balance: Some(balance),
                 total_transferred: Amount::ZERO,
+                total_refunded: Amount::ZERO,
+                sequencer: None,
+            }
+        }
+
+        fn with_balance_and_sequencer(
+            balance: Amount,
+            sequencer: <TestSpec as crate::Spec>::Address,
+        ) -> Self {
+            Self {
+                balance: Some(balance),
+                total_transferred: Amount::ZERO,
+                total_refunded: Amount::ZERO,
+                sequencer: Some(sequencer),
             }
         }
     }
@@ -820,12 +838,20 @@ mod tests {
 
         fn transfer_gas_tokens(
             &mut self,
-            _from: &S::Address,
+            from: &S::Address,
             _to: &S::Address,
             amount: Amount,
             _state: &mut impl StateAccessor,
         ) -> Result<(), GasBillingError> {
             self.total_transferred = self.total_transferred.checked_add(amount).unwrap();
+            // Detect refund: sequencer is the sender
+            if let Some(ref seq) = self.sequencer {
+                let seq_bytes = borsh::to_vec(seq).unwrap();
+                let from_bytes = borsh::to_vec(from).unwrap();
+                if seq_bytes == from_bytes {
+                    self.total_refunded = self.total_refunded.checked_add(amount).unwrap();
+                }
+            }
             Ok(())
         }
     }
@@ -2092,5 +2118,77 @@ mod tests {
         let mut metric = StateAccessMetric::new_read();
         let read_value = layered_state.get_value(namespace, &key, &mut metric);
         assert_eq!(read_value, Some(value), "Data should be committed");
+    }
+
+    #[test]
+    fn test_priority_fee_bips_billing() {
+        use crate::{Amount, Gas, GasMeter, Spec};
+        let storage_manager = SimpleStorageManager::new();
+        let storage = storage_manager.create_storage();
+
+        // gas_price = 1 per dimension, so gas cost = sum of dimension values
+        let gas_price = <<TestSpec as Spec>::Gas as Gas>::Price::from([Amount::new(1); 2]);
+        let initial_funds = Amount::new(10_000);
+        let mut working_set =
+            WorkingSet::<TestSpec>::new_with_gas_meter(storage, initial_funds, &gas_price);
+
+        let mut layered_state = LayeredRevertableTxState::new(&mut working_set);
+
+        let gas_payer = <TestSpec as crate::Spec>::Address::from([1u8; 28]);
+        let sequencer = <TestSpec as crate::Spec>::Address::from([2u8; 28]);
+        let gas_limit = <TestSpec as Spec>::Gas::from([100u64, 100u64]);
+
+        // 500 bips = 5% priority fee
+        let priority_fee_bips = 500u64;
+        let mut biller = MockBiller::with_balance_and_sequencer(Amount::MAX, sequencer);
+
+        layered_state
+            .add_revertable_layer_with_gas_payer(
+                gas_payer,
+                gas_limit,
+                &sequencer,
+                &mut biller,
+                priority_fee_bips,
+            )
+            .unwrap();
+
+        // Upfront charge should be gas_cost + 5% = 200 + 10 = 210
+        let gas_cost = gas_limit.value(gas_price); // 100*1 + 100*1 = 200
+        let expected_upfront = Amount::new(gas_cost.0 + gas_cost.0 * 500 / 10_000); // 210
+        assert_eq!(
+            biller.total_transferred, expected_upfront,
+            "Upfront charge should include 5% priority fee"
+        );
+
+        // Consume 40 gas per dimension (80 total cost at price=1)
+        let gas_to_charge = <TestSpec as Spec>::Gas::from([40u64, 40u64]);
+        if let Some(meter) = layered_state.inner.try_as_basic_gas_meter() {
+            meter.charge_gas(gas_to_charge).expect("Should charge gas");
+        }
+        layered_state.track_gas_in_layer(gas_to_charge);
+
+        // Commit — should refund unused portion
+        layered_state
+            .commit_layer(&mut biller, &sequencer)
+            .expect("commit_layer should succeed");
+
+        // actual_cost = 80, actual_priority = 80 * 500 / 10_000 = 4, actual_total = 84
+        // refund = 210 - 84 = 126
+        let actual_cost = gas_to_charge.value(gas_price); // 80
+        let actual_priority = Amount::new(actual_cost.0 * 500 / 10_000); // 4
+        let actual_total = Amount::new(actual_cost.0 + actual_priority.0); // 84
+        let expected_refund = Amount::new(expected_upfront.0 - actual_total.0); // 126
+
+        assert_eq!(
+            biller.total_refunded, expected_refund,
+            "Refund should return unused gas + unused priority fee reservation"
+        );
+
+        // Net cost to payer = upfront - refund = actual_total = 84
+        let net_cost = Amount::new(expected_upfront.0 - biller.total_refunded.0);
+        assert_eq!(
+            net_cost, actual_total,
+            "Net cost should equal actual gas + actual priority fee"
+        );
     }
 }

--- a/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/layered_revertable_tx_state.rs
+++ b/crates/module-system/sov-modules-api/src/state/accessors/scratchpad/layered_revertable_tx_state.rs
@@ -37,9 +37,13 @@ pub struct GasSnapshot<S: Spec> {
     /// Outer payer's remaining funds (to restore on layer end).
     pub outer_remaining_funds: Amount,
     /// Amount charged upfront when layer was created (for refund calculation).
+    /// Includes both base gas cost and priority fee reservation.
     pub upfront_charge: Amount,
     /// Gas price at layer creation (for refund calculation).
     pub gas_price: <S::Gas as Gas>::Price,
+    /// Priority fee rate in basis points (1 bip = 0.01%).
+    /// Priority fee = actual_base_cost * priority_fee_bips / 10_000.
+    pub priority_fee_bips: u64,
 }
 
 /// Billing info extracted from a layer before it's consumed (committed/reverted).
@@ -253,9 +257,15 @@ impl<'a, S: Spec, I: TxState<S>> LayeredRevertableTxState<'a, S, I> {
         gas_limit: S::Gas,
         sequencer: &S::Address,
         biller: &mut B,
+        priority_fee_bips: u64,
     ) -> Result<&mut Self, GasPayerError<S::Gas>> {
-        let gas_snapshot =
-            self.validate_and_swap_gas_payer(gas_payer, gas_limit, sequencer, biller)?;
+        let gas_snapshot = self.validate_and_swap_gas_payer(
+            gas_payer,
+            gas_limit,
+            sequencer,
+            biller,
+            priority_fee_bips,
+        )?;
         self.layers
             .push(StateLayer::new_with_gas_payer(gas_payer, gas_snapshot));
         Ok(self)
@@ -276,6 +286,7 @@ impl<'a, S: Spec, I: TxState<S>> LayeredRevertableTxState<'a, S, I> {
         gas_limit: S::Gas,
         sequencer: &S::Address,
         biller: &mut B,
+        priority_fee_bips: u64,
     ) -> Result<GasSnapshot<S>, GasPayerError<S::Gas>> {
         // Phase 1: Read meter values (borrow meter, extract values, drop borrow)
         let (remaining_gas, remaining_funds, gas_cost, gas_price) = {
@@ -296,6 +307,11 @@ impl<'a, S: Spec, I: TxState<S>> LayeredRevertableTxState<'a, S, I> {
             (meter.remaining_gas, remaining_funds, gas_cost, gas_price)
         }; // meter borrow dropped
 
+        // Include priority fee in the upfront reservation so the full amount is locked
+        // before execution. upfront = base_cost + base_cost * priority_fee_bips / 10_000
+        let priority_reservation = Amount(gas_cost.0 * priority_fee_bips as u128 / 10_000);
+        let upfront_charge = Amount(gas_cost.0.saturating_add(priority_reservation.0));
+
         // Phase 2: Read gas payer's balance (borrow self.inner as StateAccessor)
         let payer_balance = biller
             .gas_balance_of(&gas_payer, self.inner)?
@@ -303,19 +319,19 @@ impl<'a, S: Spec, I: TxState<S>> LayeredRevertableTxState<'a, S, I> {
                 payer: format!("{:?}", gas_payer),
             })?;
 
-        // Validate gas payer can afford the gas limit
-        if payer_balance < gas_cost {
+        // Validate gas payer can afford the gas limit + priority fee
+        if payer_balance < upfront_charge {
             return Err(GasPayerError::InsufficientPayerBalance {
-                required: gas_cost,
+                required: upfront_charge,
                 available: payer_balance,
             });
         }
 
-        // Phase 3: Charge upfront - transfer gas_cost from payer to sequencer
+        // Phase 3: Charge upfront - transfer upfront_charge from payer to sequencer
         // This ensures the payment is secured before execution begins
-        if gas_cost > Amount::ZERO {
+        if upfront_charge > Amount::ZERO {
             biller
-                .transfer_gas_tokens(&gas_payer, sequencer, gas_cost, self.inner)
+                .transfer_gas_tokens(&gas_payer, sequencer, upfront_charge, self.inner)
                 .map_err(GasPayerError::BillingError)?;
         }
 
@@ -323,15 +339,16 @@ impl<'a, S: Spec, I: TxState<S>> LayeredRevertableTxState<'a, S, I> {
         let snapshot = GasSnapshot {
             outer_remaining_gas: remaining_gas,
             outer_remaining_funds: remaining_funds,
-            upfront_charge: gas_cost,
+            upfront_charge,
             gas_price,
+            priority_fee_bips,
         };
 
         if let Some(meter) = self.inner.try_as_basic_gas_meter() {
-            // Perform the meter swap: set remaining_funds to the gas limit cost
+            // Perform the meter swap: set remaining_funds to the upfront charge
             // and set remaining_gas to the requested gas_limit to give the gas payer
             // an independent budget (not constrained by outer meter's remaining_gas)
-            meter.remaining_funds = Some(gas_cost);
+            meter.remaining_funds = Some(upfront_charge);
             meter.remaining_gas = gas_limit;
         }
 
@@ -374,12 +391,18 @@ impl<'a, S: Spec, I: TxState<S>> LayeredRevertableTxState<'a, S, I> {
         // Phase 1: Calculate actual gas cost using stored gas_price
         let actual_cost = info.gas_consumed.value(info.gas_snapshot.gas_price);
 
+        // Priority fee is charged on actual consumption: actual_base * priority_fee_bips / 10_000
+        let actual_priority_fee =
+            Amount(actual_cost.0 * info.gas_snapshot.priority_fee_bips as u128 / 10_000);
+        let actual_total = Amount(actual_cost.0.saturating_add(actual_priority_fee.0));
+
         // Phase 2: Calculate and transfer refund (borrow self.inner as StateAccessor)
         // Upfront charge was already paid at layer creation, now refund unused portion
+        // Refund = upfront - actual_total (unused base gas + unused priority fee reservation)
         let refund = info
             .gas_snapshot
             .upfront_charge
-            .checked_sub(actual_cost)
+            .checked_sub(actual_total)
             .unwrap_or(Amount::ZERO);
 
         if refund > Amount::ZERO {
@@ -1557,6 +1580,7 @@ mod tests {
                 gas_limit,
                 &sequencer,
                 &mut biller,
+                0,
             )
             .unwrap();
 
@@ -1593,7 +1617,7 @@ mod tests {
         let gas_limit = <TestSpec as Spec>::Gas::ZEROED;
         let mut biller = MockBiller::with_balance(Amount::MAX);
         layered_state
-            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller)
+            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller, 0)
             .unwrap();
 
         // Write data in gas payer layer
@@ -1643,7 +1667,7 @@ mod tests {
         let gas_limit = <TestSpec as Spec>::Gas::ZEROED;
         let mut biller = MockBiller::with_balance(Amount::MAX);
         layered_state
-            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller)
+            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller, 0)
             .unwrap();
         layered_state.set_value(namespace, &inner_key, inner_value.clone());
 
@@ -1694,7 +1718,7 @@ mod tests {
         let gas_limit = <TestSpec as Spec>::Gas::from([50u64, 50u64]);
         let mut biller = MockBiller::with_balance(Amount::MAX);
         layered_state
-            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller)
+            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller, 0)
             .unwrap();
 
         // Write data
@@ -1746,7 +1770,7 @@ mod tests {
         let gas_limit = <TestSpec as Spec>::Gas::ZEROED;
         let mut biller = MockBiller::with_balance(Amount::MAX);
         layered_state
-            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller)
+            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller, 0)
             .unwrap();
 
         // Initially, gas_consumed should be ZEROED
@@ -1782,7 +1806,7 @@ mod tests {
         let gas_limit = <TestSpec as Spec>::Gas::from([100u64, 100u64]); // Well under our 1000 funds
         let mut biller = MockBiller::with_balance(Amount::MAX);
         layered_state
-            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller)
+            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller, 0)
             .unwrap();
 
         // Verify snapshot captured the OUTER payer's funds (before meter swap)
@@ -1867,6 +1891,7 @@ mod tests {
             large_gas_limit,
             &sequencer,
             &mut biller,
+            0,
         );
         // Should succeed - gas payer gets independent budget
         assert!(
@@ -1907,6 +1932,7 @@ mod tests {
             zero_gas_limit,
             &sequencer,
             &mut biller,
+            0,
         );
         assert!(result.is_ok(), "Zero gas limit should be allowed");
     }
@@ -1934,7 +1960,7 @@ mod tests {
         let mut biller = MockBiller::with_balance(Amount::MAX);
 
         layered_state
-            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller)
+            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller, 0)
             .expect("Should create gas payer layer");
 
         // Simulate gas consumption by charging the meter
@@ -1987,7 +2013,7 @@ mod tests {
         let mut biller = MockBiller::with_balance(Amount::MAX);
 
         layered_state
-            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller)
+            .add_revertable_layer_with_gas_payer(gas_payer, gas_limit, &sequencer, &mut biller, 0)
             .expect("Should create gas payer layer");
 
         // Write some data (this will be reverted)

--- a/crates/module-system/sov-modules-api/src/transaction/data.rs
+++ b/crates/module-system/sov-modules-api/src/transaction/data.rs
@@ -16,6 +16,7 @@ use crate::{Amount, BasicGasMeter, Gas, GasArray, Spec};
 #[derive(
     From,
     Into,
+    Default,
     Serialize,
     Deserialize,
     BorshSerialize,
@@ -27,6 +28,7 @@ use crate::{Amount, BasicGasMeter, Gas, GasArray, Spec};
     Eq,
     PartialOrd,
     Ord,
+    schemars::JsonSchema,
     sov_rollup_interface::sov_universal_wallet::UniversalWallet,
 )]
 pub struct PriorityFeeBips(pub u64);


### PR DESCRIPTION
Add `priority_fee_bips: u64` to `GasSnapshot` and thread it through `add_revertable_layer_with_gas_payer` and `validate_and_swap_gas_payer`.

Billing math:
  upfront_charge = base_cost + base_cost * bips / 10_000
  actual_total   = actual_cost + actual_cost * bips / 10_000
  refund         = upfront_charge - actual_total

Passing bips=0 is fully backward-compatible with all existing callers.

Also add `Default` and `JsonSchema` derives to `PriorityFeeBips`.

# Description

*Summary of the changes...*

- [ ] I have updated `CHANGELOG.md` with a new entry if my PR makes any breaking changes or fixes a bug. If my PR removes a feature or changes its behavior, I provide help for users on how to migrate to the new behavior.
- [ ] I have carefully reviewed all my `Cargo.toml` changes before opening the PRs. (Are all new dependencies necessary? Is any module dependency leaked into the full-node (hint: it shouldn't)?)

## Linked Issues
- Fixes # (issue, if applicable)
- Related to # (issue) 

## Testing
Describe how these changes were tested. If you've added new features, have you added unit tests?

## Docs
Describe where this code is documented. If it changes a documented interface, have the docs been updated?

Rendered docs are available at `https://sovlabs-ci-rustdoc-artifacts.us-east-1.amazonaws.com/<BRANCH_NAME>/index.html`
