### PR TITLE
Add /healthz and /readyz endpoints

### DIFF
--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -176,7 +176,8 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
                 "/sequencer/unstable/events",
                 axum::routing::get(Self::axum_list_events),
             )
-            .route("/sequencer/role", axum::routing::get(Self::axum_get_role));
+            .route("/sequencer/role", axum::routing::get(Self::axum_get_role))
+            .route("/readyz", axum::routing::get(Self::axum_get_readyz));
 
         #[cfg(feature = "test-utils")]
         let router = router
@@ -459,6 +460,21 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
 
     async fn axum_get_role(state: State<Self>) -> ApiResult<crate::SequencerRole> {
         Ok(state.sequencer.sequencer_role().await.into())
+    }
+
+    async fn axum_get_readyz(state: State<Self>) -> ApiResult<()> {
+        if let Err(details) = state.sequencer.is_ready().await {
+            return Err(error_not_fully_synced(details).into_response());
+        }
+        if state.sequencer.sequencer_role().await != crate::SequencerRole::BatchProducer {
+            return Err(sov_rest_utils::ErrorObject {
+                status: axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                message: "Node is not the leader".to_string(),
+                details: Default::default(),
+            }
+            .into_response());
+        }
+        Ok(().into())
     }
 
     async fn axum_get_tx_status(

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -177,6 +177,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
                 axum::routing::get(Self::axum_list_events),
             )
             .route("/sequencer/role", axum::routing::get(Self::axum_get_role))
+            // TODO: Should realistically be /sequencer/readyz, but leaving as /readyz for now.
             .route("/readyz", axum::routing::get(Self::axum_get_readyz));
 
         #[cfg(feature = "test-utils")]

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -462,7 +462,9 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
         Ok(state.sequencer.sequencer_role().await.into())
     }
 
-    async fn axum_get_readyz(state: State<Self>) -> ApiResult<()> {
+    async fn axum_get_readyz(
+        state: State<Self>,
+    ) -> Result<&'static str, axum::response::Response> {
         if let Err(details) = state.sequencer.is_ready().await {
             return Err(error_not_fully_synced(details).into_response());
         }
@@ -474,7 +476,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             }
             .into_response());
         }
-        Ok(().into())
+        Ok("ok")
     }
 
     async fn axum_get_tx_status(

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -463,9 +463,7 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
         Ok(state.sequencer.sequencer_role().await.into())
     }
 
-    async fn axum_get_readyz(
-        state: State<Self>,
-    ) -> Result<&'static str, axum::response::Response> {
+    async fn axum_get_readyz(state: State<Self>) -> Result<&'static str, axum::response::Response> {
         if let Err(details) = state.sequencer.is_ready().await {
             return Err(error_not_fully_synced(details).into_response());
         }

--- a/crates/module-system/sov-modules-rollup-blueprint/src/native_only/endpoints.rs
+++ b/crates/module-system/sov-modules-rollup-blueprint/src/native_only/endpoints.rs
@@ -81,6 +81,10 @@ where
         "/healthcheck",
         sov_modules_api::prelude::axum::routing::get(|| async { "ok" }),
     );
+    endpoints.axum_router = endpoints.axum_router.route(
+        "/healthz",
+        sov_modules_api::prelude::axum::routing::get(|| async { "ok" }),
+    );
     endpoints.axum_router = endpoints.axum_router.fallback(errors::global_404);
 
     // Even if runtime does not have Open API spec, we still want to plug in Sequencer and Ledger.

--- a/crates/rollup-interface/src/state_machine/stf/batch.rs
+++ b/crates/rollup-interface/src/state_machine/stf/batch.rs
@@ -236,11 +236,7 @@ mod tests {
 
     #[test]
     fn test_max_raw_tx_size_is_10_kb() {
-        assert_eq!(
-            MAX_RAW_TX_SIZE,
-            10 * 1024,
-            "MAX_RAW_TX_SIZE must be 10 KB"
-        );
+        assert_eq!(MAX_RAW_TX_SIZE, 10 * 1024, "MAX_RAW_TX_SIZE must be 10 KB");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `/healthz` liveness probe alongside existing `/healthcheck`
- Adds `/readyz` readiness probe for Kubernetes-style health checking

## Endpoint Details

### `GET /healthz`
Liveness probe. Returns `200 OK` with body `"ok"` unconditionally — confirms the HTTP server is running and can serve requests. No checks are performed.

### `GET /readyz`
Readiness probe. Returns `200 OK` (empty body) only when **both** conditions are met:

1. **Sequencer is ready** (`is_ready()` passes) — this fails with `503` during any of:
   - **Startup** — sequencer is still initializing
   - **Syncing** — node is catching up to DA chain tip
   - **WaitingOnDa** — DA layer hasn't finalized enough blocks
   - **WaitingOnBlobSender** — blob sender is backpressured
   - **PreferredSequencerRecovering** — dropped out of sync, attempting recovery
   - **PreferredSequencerAtStopHeight** — reached configured stop height
   - **Shutdown** — node is shutting down
   - **ReplicaNotReady** — replica waiting for first batch from master

2. **Node is the leader** (`sequencer_role() == BatchProducer`) — returns `503` with `"Node is not the leader"` if the role is `DaOnlyReplica` or `PgSyncReplica`

## Test plan
- [ ] Verify `/healthz` returns 200 on any running node
- [ ] Verify `/readyz` returns 200 on a synced leader node
- [ ] Verify `/readyz` returns 503 on a replica node
- [ ] Verify `/readyz` returns 503 during shutdown