### PR TITLE
Add sequencer transaction ingress gate

### DIFF
--- a/crates/full-node/sov-sequencer/src/common.rs
+++ b/crates/full-node/sov-sequencer/src/common.rs
@@ -136,6 +136,72 @@ pub(crate) type SequencerEventStream<Rt> = Pin<
     >,
 >;
 
+/// Current transaction ingress status for the sequencer.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct TxIngressStatus {
+    /// Whether new transactions are accepted.
+    pub enabled: bool,
+    /// Optional operator-provided reason for the current state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Optional operator identity or automation name that last updated the state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_by: Option<String>,
+    /// Optional timestamp for the last update.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+    /// Monotonically increasing update generation.
+    pub generation: u64,
+}
+
+impl Default for TxIngressStatus {
+    fn default() -> Self {
+        Self::enabled()
+    }
+}
+
+impl TxIngressStatus {
+    /// Returns the default enabled ingress status.
+    pub fn enabled() -> Self {
+        Self {
+            enabled: true,
+            reason: None,
+            updated_by: None,
+            updated_at: None,
+            generation: 0,
+        }
+    }
+}
+
+/// Request body for changing transaction ingress status.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SetTxIngressStatus {
+    /// Whether new transactions should be accepted.
+    pub enabled: bool,
+    /// Optional operator-provided reason for this change.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Optional operator identity or automation name performing this change.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_by: Option<String>,
+}
+
+/// Returns a 503 error for transaction submissions while ingress is disabled.
+pub fn tx_ingress_disabled(status: TxIngressStatus) -> ErrorObject {
+    ErrorObject {
+        status: StatusCode::SERVICE_UNAVAILABLE,
+        message: "Transaction ingress is disabled".to_string(),
+        details: json_obj!({
+            "error": "tx_ingress_disabled",
+            "enabled": status.enabled,
+            "reason": status.reason,
+            "updated_by": status.updated_by,
+            "updated_at": status.updated_at,
+            "generation": status.generation,
+        }),
+    }
+}
+
 /// The [`Sequencer`] trait is responsible for accepting transactions and
 /// assembling them into batches.
 #[async_trait]
@@ -187,6 +253,19 @@ pub trait Sequencer: Clone + Send + Sync + 'static {
 
     /// Checks whether the batch builder is ready to accept transactions.
     async fn is_ready(&self) -> Result<(), SequencerNotReadyDetails>;
+
+    /// Returns whether the sequencer is accepting new transaction submissions.
+    async fn tx_ingress_status(&self) -> anyhow::Result<TxIngressStatus> {
+        Ok(TxIngressStatus::enabled())
+    }
+
+    /// Sets whether the sequencer is accepting new transaction submissions.
+    async fn set_tx_ingress_status(
+        &self,
+        _status: SetTxIngressStatus,
+    ) -> anyhow::Result<TxIngressStatus> {
+        anyhow::bail!("This sequencer does not support transaction ingress control")
+    }
 
     /// Queries a transaction's status.
     async fn tx_status(

--- a/crates/full-node/sov-sequencer/src/lib.rs
+++ b/crates/full-node/sov-sequencer/src/lib.rs
@@ -19,7 +19,10 @@ use axum::async_trait;
 pub use common::ForcedTxBatchNotification;
 #[cfg(feature = "test-utils")]
 pub use common::StateUpdateNotification;
-pub use common::{react_to_state_updates, AcceptTxErrorCode, AcceptTxErrorDetails, Sequencer};
+pub use common::{
+    react_to_state_updates, AcceptTxErrorCode, AcceptTxErrorDetails, Sequencer, SetTxIngressStatus,
+    TxIngressStatus,
+};
 pub use config::{SeqConfigExtension, SequencerConfig, SequencerKindConfig, SovRateLimiterConfig};
 pub use preferred::SequencerRole;
 pub use rest_api::SequencerApis;

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/003_tx_ingress_gate.sql
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/migrations/003_tx_ingress_gate.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS tx_ingress_gate (
+    id BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id),
+    enabled BOOLEAN NOT NULL,
+    reason TEXT,
+    updated_by TEXT,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    generation BIGINT NOT NULL DEFAULT 0
+);
+
+INSERT INTO tx_ingress_gate (id, enabled, reason, updated_by, generation)
+VALUES (TRUE, TRUE, NULL, NULL, 0)
+ON CONFLICT (id) DO NOTHING;

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/mod.rs
@@ -8,6 +8,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
 use super::{DbBackend, ReadBlob, SnapshotData, StoredBlob};
+use crate::common::{SetTxIngressStatus, TxIngressStatus};
 use crate::preferred::db::DbError;
 use crate::preferred::db::{BatchToStore, DbReadOutcome, InProgressBatch};
 use anyhow::Context;
@@ -32,11 +33,41 @@ pub(crate) struct SequencerLeader {
     pub(crate) leader_acquired_at: OffsetDateTime,
 }
 
+#[derive(Debug, Clone, FromRow, PartialEq)]
+struct TxIngressGateRow {
+    enabled: bool,
+    reason: Option<String>,
+    updated_by: Option<String>,
+    updated_at: OffsetDateTime,
+    generation: i64,
+}
+
+impl TryFrom<TxIngressGateRow> for TxIngressStatus {
+    type Error = anyhow::Error;
+
+    fn try_from(row: TxIngressGateRow) -> Result<Self> {
+        Ok(Self {
+            enabled: row.enabled,
+            reason: row.reason,
+            updated_by: row.updated_by,
+            updated_at: Some(row.updated_at.to_string()),
+            generation: u64::try_from(row.generation)
+                .context("Invalid negative tx ingress generation")?,
+        })
+    }
+}
+
 pub struct PostgresBackend {
     pool: PgPool,
     backoff_policy: ExponentialBuilder,
     node_id: String,
     pub(crate) node_address: String,
+}
+
+#[derive(Clone)]
+pub(crate) struct PostgresTxIngressGate {
+    pool: PgPool,
+    backoff_policy: ExponentialBuilder,
 }
 
 // We need a macro to get around lifetime issues with async functions. Otherwise, Rust complains about FnMut
@@ -464,6 +495,99 @@ impl PostgresBackend {
             Some(leader_id) => leader_id == &self.node_id,
             None => false,
         }
+    }
+}
+
+impl PostgresTxIngressGate {
+    pub(crate) async fn connect(config: &PostgresConfig) -> Result<Self> {
+        let backoff_policy = ExponentialBuilder::default()
+            .with_jitter()
+            .with_min_delay(Duration::from_millis(2))
+            .with_max_delay(Duration::from_millis(500))
+            .with_factor(2.0)
+            .with_max_times(8);
+
+        let pool = run_with_retries!(
+            &backoff_policy,
+            PgPoolOptions::default().connect(&config.postgres_connection_string),
+            "postgres_tx_ingress_gate_connect"
+        )?;
+
+        run_with_retries!(
+            &backoff_policy,
+            sqlx::migrate!("src/preferred/db/postgres/migrations").run(&pool),
+            "postgres_tx_ingress_gate_migrate"
+        )?;
+
+        Ok(Self {
+            pool,
+            backoff_policy,
+        })
+    }
+
+    pub(crate) async fn status(&self) -> Result<TxIngressStatus> {
+        let row = run_with_retries!(
+            &self.backoff_policy,
+            self.status_inner(),
+            "postgres_tx_ingress_gate_status"
+        )?;
+        row.try_into()
+    }
+
+    pub(crate) async fn set_status(&self, status: SetTxIngressStatus) -> Result<TxIngressStatus> {
+        let status = status.clone();
+        let row = run_with_retries!(
+            &self.backoff_policy,
+            self.set_status_inner(status.clone()),
+            "postgres_tx_ingress_gate_set_status"
+        )?;
+        row.try_into()
+    }
+
+    async fn status_inner(&self) -> Result<TxIngressGateRow> {
+        self.ensure_default_row().await?;
+        let row = sqlx::query_as::<Postgres, TxIngressGateRow>(
+            "SELECT enabled, reason, updated_by, updated_at, generation
+             FROM tx_ingress_gate
+             WHERE id = TRUE",
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    async fn set_status_inner(&self, status: SetTxIngressStatus) -> Result<TxIngressGateRow> {
+        let row = sqlx::query_as::<Postgres, TxIngressGateRow>(
+            "INSERT INTO tx_ingress_gate (id, enabled, reason, updated_by, generation)
+             VALUES (TRUE, $1, $2, $3, 1)
+             ON CONFLICT (id) DO UPDATE
+             SET enabled = EXCLUDED.enabled,
+                 reason = EXCLUDED.reason,
+                 updated_by = EXCLUDED.updated_by,
+                 updated_at = NOW(),
+                 generation = tx_ingress_gate.generation + 1
+             RETURNING enabled, reason, updated_by, updated_at, generation",
+        )
+        .bind(status.enabled)
+        .bind(status.reason)
+        .bind(status.updated_by)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    async fn ensure_default_row(&self) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO tx_ingress_gate (id, enabled, reason, updated_by, generation)
+             VALUES (TRUE, TRUE, NULL, NULL, 0)
+             ON CONFLICT (id) DO NOTHING",
+        )
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
     }
 }
 

--- a/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/db/postgres/tests/db_operations.rs
@@ -1,6 +1,41 @@
 use super::*;
+use crate::SetTxIngressStatus;
 use sov_modules_api::VisibleSlotNumber;
 use std::{num::NonZero, sync::Arc};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tx_ingress_gate_persists_state() {
+    let Some(postgres) = setup_test_postgres().await else {
+        return;
+    };
+
+    let config = config_from_postgres_container(
+        &postgres,
+        String::from("node_id_1"),
+        ConfiguredNodeRole::Leader,
+    )
+    .await
+    .unwrap();
+    let gate = PostgresTxIngressGate::connect(&config).await.unwrap();
+
+    let initial_status = gate.status().await.unwrap();
+    assert!(initial_status.enabled);
+
+    let disabled_status = gate
+        .set_status(SetTxIngressStatus {
+            enabled: false,
+            reason: Some(String::from("upgrade")),
+            updated_by: Some(String::from("test")),
+        })
+        .await
+        .unwrap();
+    assert!(!disabled_status.enabled);
+    assert_eq!(disabled_status.reason.as_deref(), Some("upgrade"));
+    assert_eq!(disabled_status.updated_by.as_deref(), Some("test"));
+
+    let second_gate = PostgresTxIngressGate::connect(&config).await.unwrap();
+    assert_eq!(second_gate.status().await.unwrap(), disabled_status);
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_db_operations_leader() {

--- a/crates/full-node/sov-sequencer/src/preferred/initialization.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/initialization.rs
@@ -120,6 +120,8 @@ where
         let (api_state, checkpoint_sender) = Self::api_state(latest_state_update.storage.clone());
 
         let (blobs_sender_channel, _) = broadcast::channel(preferred_config.events_channel_size);
+        let tx_ingress_gate =
+            TxIngressGate::connect(preferred_config.postgres_config.as_ref()).await?;
 
         let (db, seq_role) = PreferredSequencerDb::new(
             shutdown_sender.clone(),
@@ -260,6 +262,7 @@ where
             api_state,
             _runtime: PhantomData,
             config: config.clone(),
+            tx_ingress_gate,
             nonce_buffer_input,
             shutdown_receiver: shutdown_receiver.clone(),
             shutdown_sender: shutdown_sender.clone(),

--- a/crates/full-node/sov-sequencer/src/preferred/mod.rs
+++ b/crates/full-node/sov-sequencer/src/preferred/mod.rs
@@ -26,7 +26,7 @@ use crate::preferred::rpc_errors::{cant_fit_tx, rate_limit, replica_mode, shut_d
 use async_trait::async_trait;
 use axum::http::StatusCode;
 use batch_size_tracker::BatchSizeTracker;
-use db::postgres::PostgresBackend;
+use db::postgres::{PostgresBackend, PostgresTxIngressGate};
 use db::rocksdb::RocksDbBackend;
 pub use db::SequencerRole;
 use db::{PreferredSequencerDb, ReadBatch, ReadBlob};
@@ -70,7 +70,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use sync_sequencer_state::*;
-use tokio::sync::{broadcast, watch};
+use tokio::sync::{broadcast, watch, RwLock};
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tracing::{error, info, trace};
@@ -78,9 +78,9 @@ use transaction_subscriptions::TransactionCache;
 
 use crate::common::{
     error_not_fully_synced, generic_accept_tx_error, loop_send_tx_notifications, poll_state_update,
-    pre_exec_err_to_accept_tx_err, AcceptedTx, ForcedTxBatchNotification, Sequencer,
-    SequencerEventStream, StateUpdateError, StateUpdateNotification, SubscriptionStreamError,
-    WithCachedTxHashes,
+    pre_exec_err_to_accept_tx_err, tx_ingress_disabled, AcceptedTx, ForcedTxBatchNotification,
+    Sequencer, SequencerEventStream, SetTxIngressStatus, StateUpdateError, StateUpdateNotification,
+    SubscriptionStreamError, TxIngressStatus, WithCachedTxHashes,
 };
 use crate::metrics::{track_in_progress_batch_size, PreferredSequencerFetchBatchesToReplayMetrics};
 use crate::preferred::block_executor::{RollupBlockExecutor, RollupBlockExecutorError};
@@ -97,6 +97,49 @@ type VisibleSlotNumberIncrease = NonZero<u8>;
 
 // Big info dump for the user that would make the code hard to read if it were inline.
 const RECOVERY_ERROR_MESSAGE_ON_NONE_STRATEGY: &str = "The preferred sequencer is too far behind, and the visible slot number has lagged more than the allowed deferred slots count. This means some non-preferred batches may have been included by the node, if there were any. If this happened, already provided soft confirmations may now no longer be valid. Because the recovery_strategy config was set to None, we are not attempting recovery at this point. You should either: a) delete everything from the preferred_sequencer database (thus annulling all currently pending soft confirmations), which will allow you to restart the sequencer fresh; or b) set the recovery_strategy config value to TryToSave, in which case all pending batches will be flushed to be executed on a best-effort basis. The latter may save some soft-confirmations if they have not been invalidated yet. However, IF a non-preferred batch has been included, AND some soft-confirmations have been invalidated by it, this will cause the sequencer to be penalised for every invalid batch; ensure your sequencer bond is sufficient to cover any penalties to be able to continue operating uninterrupted.";
+
+#[derive(Clone)]
+enum TxIngressGate {
+    Postgres(PostgresTxIngressGate),
+    InMemory(Arc<RwLock<TxIngressStatus>>),
+}
+
+impl TxIngressGate {
+    async fn connect(postgres_config: Option<&PostgresConfig>) -> anyhow::Result<Self> {
+        match postgres_config {
+            Some(config) if config.node_role != ConfiguredNodeRole::ReplicaNoLeaderSync => Ok(
+                Self::Postgres(PostgresTxIngressGate::connect(config).await?),
+            ),
+            None => Ok(Self::InMemory(Arc::new(RwLock::new(
+                TxIngressStatus::enabled(),
+            )))),
+            Some(_) => Ok(Self::InMemory(Arc::new(RwLock::new(
+                TxIngressStatus::enabled(),
+            )))),
+        }
+    }
+
+    async fn status(&self) -> anyhow::Result<TxIngressStatus> {
+        match self {
+            Self::Postgres(gate) => gate.status().await,
+            Self::InMemory(status) => Ok(status.read().await.clone()),
+        }
+    }
+
+    async fn set_status(&self, request: SetTxIngressStatus) -> anyhow::Result<TxIngressStatus> {
+        match self {
+            Self::Postgres(gate) => gate.set_status(request).await,
+            Self::InMemory(status) => {
+                let mut status = status.write().await;
+                status.enabled = request.enabled;
+                status.reason = request.reason;
+                status.updated_by = request.updated_by;
+                status.generation += 1;
+                Ok(status.clone())
+            }
+        }
+    }
+}
 
 /// A [`Sequencer`] with instant transaction confirmation.
 #[derive(derivative::Derivative, Deref)]
@@ -121,6 +164,7 @@ where
     api_state: ApiState<S>,
     _runtime: PhantomData<(Rt, Da)>,
     pub(crate) config: SequencerConfig<S::Address, PreferredSequencerConfig<S::Address>>,
+    tx_ingress_gate: TxIngressGate,
     /// Used for intelligently buffering nonce-based TXs if they arrive out of order.
     nonce_buffer_input: NonceBufferInputSender<SequencerTxExecutionBackend<S, Rt>, S, Rt>,
     shutdown_receiver: watch::Receiver<()>,
@@ -386,6 +430,20 @@ where
         if self.shutdown_receiver.has_changed().unwrap_or(true) {
             tracing::info!("The sequencer is shutting down. Cannot accept transactions");
             return Err(shut_down());
+        }
+
+        let ingress_status = self
+            .tx_ingress_gate
+            .status()
+            .await
+            .map_err(database_error_500)?;
+        if !ingress_status.enabled {
+            tracing::info!(
+                reason = ?ingress_status.reason,
+                generation = ingress_status.generation,
+                "Transaction ingress is disabled. Cannot accept transactions"
+            );
+            return Err(tx_ingress_disabled(ingress_status));
         }
 
         let original_tx_queue_id = self.tx_queue_id.load(Ordering::Acquire);
@@ -793,6 +851,17 @@ where
             .await
             .map_err(|_| SequencerNotReadyDetails::Shutdown)?
             .map(|_| ())
+    }
+
+    async fn tx_ingress_status(&self) -> anyhow::Result<TxIngressStatus> {
+        self.tx_ingress_gate.status().await
+    }
+
+    async fn set_tx_ingress_status(
+        &self,
+        status: SetTxIngressStatus,
+    ) -> anyhow::Result<TxIngressStatus> {
+        self.tx_ingress_gate.set_status(status).await
     }
 
     fn api_state(&self) -> ApiState<Self::Spec> {

--- a/crates/full-node/sov-sequencer/src/rest_api.rs
+++ b/crates/full-node/sov-sequencer/src/rest_api.rs
@@ -33,7 +33,10 @@ use tokio::sync::watch::Receiver;
 use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 use tokio_stream::wrappers::BroadcastStream;
 
-use crate::common::{error_not_fully_synced, AcceptedTx, Sequencer, SubscriptionStreamError};
+use crate::common::{
+    error_not_fully_synced, AcceptedTx, Sequencer, SetTxIngressStatus, SubscriptionStreamError,
+    TxIngressStatus,
+};
 use crate::TxStatus;
 
 /// Interval between ping frames sent to the client for keepalive.
@@ -168,6 +171,11 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             .route(
                 "/sequencer/txs/submit/ws",
                 axum::routing::get(Self::axum_ws_submit_tx),
+            )
+            .route(
+                "/admin/sequencer/tx-ingress",
+                axum::routing::get(Self::axum_get_tx_ingress_status)
+                    .put(Self::axum_set_tx_ingress_status),
             )
             .route(
                 "/sequencer/unstable/events/:eventId",
@@ -465,6 +473,37 @@ impl<Seq: Sequencer> SequencerApis<Seq> {
             Ok(()) => Ok(().into()),
             Err(details) => Err(error_not_fully_synced(details).into_response()),
         }
+    }
+
+    async fn axum_get_tx_ingress_status(state: State<Self>) -> ApiResult<TxIngressStatus> {
+        state
+            .sequencer
+            .tx_ingress_status()
+            .await
+            .map(Into::into)
+            .map_err(|e| {
+                tracing::error!(error = %e, "Error reading transaction ingress status");
+                errors::internal_server_error_response_500(
+                    "Unable to read transaction ingress status",
+                )
+            })
+    }
+
+    async fn axum_set_tx_ingress_status(
+        state: State<Self>,
+        request: Json<SetTxIngressStatus>,
+    ) -> ApiResult<TxIngressStatus> {
+        state
+            .sequencer
+            .set_tx_ingress_status(request.0)
+            .await
+            .map(Into::into)
+            .map_err(|e| {
+                tracing::error!(error = %e, "Error updating transaction ingress status");
+                errors::internal_server_error_response_500(
+                    "Unable to update transaction ingress status",
+                )
+            })
     }
 
     async fn axum_get_role(state: State<Self>) -> ApiResult<crate::SequencerRole> {


### PR DESCRIPTION
## Summary
- add admin GET/PUT endpoints for sequencer tx ingress status
- gate preferred sequencer `accept_tx` before authentication/execution so HTTP, websocket, and custom submit paths are covered
- persist clustered gate state in Postgres and add a migration + persistence test

## Verification
- `cargo fmt -p sov-sequencer`
- `SKIP_GUEST_BUILD=1 cargo check -p sov-sequencer --lib`
- `SKIP_GUEST_BUILD=1 cargo nextest run -p sov-sequencer test_tx_ingress_gate_persists_state`

## Notes
- This is stacked on `feat/synced-only-db-elected-promotion` to keep the PR diff focused.
- A broader `SKIP_GUEST_BUILD=1 cargo nextest run -p sov-sequencer --no-fail-fast` run completed with unrelated-looking failures/timeouts: `preferred_with_proofs::flaky_test_proof_generation_doesnt_break_sequencer`, `standard_sequencer::test_reject_transaction_exceeding_max_raw_tx_size`, and `preferred_end_to_end::seq_behind_deferred_slots_count_with_shutdown`.
